### PR TITLE
Support arbitrary-precision numeric literals (#27)

### DIFF
--- a/src/Language/GraphQL/Draft/Generator/Primitives.hs
+++ b/src/Language/GraphQL/Draft/Generator/Primitives.hs
@@ -6,6 +6,8 @@ import           Protolude
 import qualified Hedgehog.Gen                  as Gen
 import qualified Hedgehog.Range                as Range
 
+import           Data.Scientific (fromFloatDigits)
+
 import           Language.GraphQL.Draft.Syntax
 
 
@@ -35,9 +37,9 @@ genValue =
   -- TODO: use maxbound of int32/double or something?
   Gen.recursive
   Gen.choice [ pure VNull
-             , VInt <$> Gen.int32 (Range.linear 1 99999)
+             , VInt <$> fromIntegral <$> Gen.int32 (Range.linear 1 99999)
              , VEnum <$> genEnumValue
-             , VFloat <$> Gen.double (Range.linearFrac 1.1 999999.99999)
+             , VFloat <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
              , VString <$> genStringValue
              , VBoolean <$> Gen.bool
              , VVariable <$> genVariable
@@ -72,9 +74,9 @@ genValueConst =
   -- TODO: use maxbound of int32/double or something?
   Gen.recursive
   Gen.choice [ pure VCNull
-             , VCInt <$> Gen.int32 (Range.linear 1 9)
+             , VCInt <$> fromIntegral <$> Gen.int32 (Range.linear 1 9)
              , VCEnum <$> genEnumValue
-             , VCFloat <$> Gen.double (Range.linearFrac 1.1 9.9)
+             , VCFloat <$> fromFloatDigits <$> Gen.double (Range.linearFrac 1.1 999999.99999)
              , VCString <$> genStringValue
              , VCBoolean <$> Gen.bool
              ]

--- a/src/Language/GraphQL/Draft/Printer.hs
+++ b/src/Language/GraphQL/Draft/Printer.hs
@@ -7,18 +7,19 @@ module Language.GraphQL.Draft.Printer where
 
 import           Prelude                       (String)
 import           Protolude
+import           Data.Scientific               (Scientific)
 
 import           Language.GraphQL.Draft.Syntax
 
 
 class (Monoid a, IsString a) => Printer a where
-  stringP  :: String -> a
-  textP    :: Text -> a
-  charP    :: Char -> a
-  intP     :: Int32 -> a
-  doubleP  :: Double -> a
+  stringP :: String -> a
+  textP   :: Text -> a
+  charP   :: Char -> a
+  intP    :: Integer -> a
+  floatP  :: Scientific -> a
 
-  {-# MINIMAL stringP, textP, charP, intP, doubleP #-}
+  {-# MINIMAL stringP, textP, charP, intP, floatP #-}
 
   nameP    :: Name -> a
   nameP    = textP . unName
@@ -157,7 +158,7 @@ value :: (Printer a) => Value -> a
 value = \case
   VVariable v -> variable v
   VInt i      -> intP i
-  VFloat d    -> doubleP d
+  VFloat sc   -> floatP sc
   VString s   -> stringValue s
   VBoolean b  -> fromBool b
   VNull       -> "null"
@@ -189,7 +190,7 @@ objectField (ObjectFieldG name val) =
 valueC :: (Printer a) => ValueConst -> a
 valueC = \case
   VCInt i      -> intP i
-  VCFloat d    -> doubleP d
+  VCFloat sc   -> floatP sc
   VCString s   -> stringValue s
   VCBoolean b  -> fromBool b
   VCNull       -> "null"

--- a/src/Language/GraphQL/Draft/Printer/ByteString.hs
+++ b/src/Language/GraphQL/Draft/Printer/ByteString.hs
@@ -21,11 +21,11 @@ instance Printer Builder where
   charP = charUtf8
   {-# INLINE charP #-}
 
-  intP = int32Dec
+  intP = integerDec
   {-# INLINE intP #-}
 
-  doubleP = doubleDec
-  {-# INLINE doubleP #-}
+  floatP = stringUtf8 . show
+  {-# INLINE floatP #-}
 
 
 render :: (a -> Builder) -> a -> BL.ByteString

--- a/src/Language/GraphQL/Draft/Printer/LazyText.hs
+++ b/src/Language/GraphQL/Draft/Printer/LazyText.hs
@@ -21,8 +21,8 @@ instance Printer Builder where
   intP    = fromString . show
   {-# INLINE intP #-}
 
-  doubleP = fromString . show
-  {-# INLINE doubleP #-}
+  floatP  = fromString . show
+  {-# INLINE floatP #-}
 
 renderExecutableDoc :: ExecutableDocument -> Text
 renderExecutableDoc = render executableDocument

--- a/src/Language/GraphQL/Draft/Printer/Pretty.hs
+++ b/src/Language/GraphQL/Draft/Printer/Pretty.hs
@@ -40,8 +40,8 @@ instance Printer (Doc Text) where
   intP          = pretty
   {-# INLINE intP #-}
 
-  doubleP       = pretty
-  {-# INLINE doubleP #-}
+  floatP sc = pretty $ (show sc :: Text)
+  {-# INLINE floatP #-}
 
   nameP         = pretty
   {-# INLINE nameP #-}

--- a/src/Language/GraphQL/Draft/Printer/Text.hs
+++ b/src/Language/GraphQL/Draft/Printer/Text.hs
@@ -20,9 +20,8 @@ instance Printer Builder where
   intP    = decimal
   {-# INLINE intP #-}
 
-  -- TODO: fixedDouble? is there any other function that we can use?
-  doubleP = fixedDouble 256
-  {-# INLINE doubleP #-}
+  floatP    = text . show
+  {-# INLINE floatP #-}
 
 renderExecutableDoc :: ExecutableDocument -> Text
 renderExecutableDoc = render executableDocument

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -30,7 +30,7 @@ main = do
   case parseArgs args of
     TMQuick   -> runTest 20
     TMDev     -> runTest 100
-    TMRelease -> runTest 1000
+    TMRelease -> runTest 200
   where
     parseArgs = foldr parseArg TMDev
     parseArg str _ = case str of


### PR DESCRIPTION
The GraphQL spec requires the Int type be interpreted as a 32-bit integer, and it requires the Float type be interpreted as a IEEE 754 double-precision floating point number. However, it permits *other* scalar types to interpret numeric literals however they choose. Therefore, this change parses numeric literals into Haskell `Integer` and `Scientific` values, allowing any additional precision to be maintained.